### PR TITLE
Force copy req.headers into new extenededReq

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -62,6 +62,7 @@ const HapiAccessLogger = {
 
       const extendedReq = {
         ...req,
+        headers: req.headers,
         timestamp: receivedTime.toISOString(),
       };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softonic/hapi-access-logger",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "author": "Rubén Norte <ruben.norte@softonic.com>",
   "description": "Hapi plugin to log all requests and responses",
   "keywords": [


### PR DESCRIPTION
On new node versions the headers property is a getter and is not copied with the deconstruct operator.